### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -11,15 +11,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -34,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "exolnet/laravel-html-list": "^3.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^2.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.7.1"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the project's dependencies and CI workflow to add support for Laravel 13 and PHPUnit 12, ensuring compatibility with the latest versions. The changes also improve the test matrix to better reflect supported combinations and allow for manual workflow dispatches.

**Dependency and compatibility updates:**

* Added support for Laravel 13 by updating the `illuminate/support` and `orchestra/testbench` version constraints in `composer.json`.
* Added support for PHPUnit 12 by updating the `phpunit/phpunit` version constraint in `composer.json`.

**CI workflow improvements:**

* Updated the GitHub Actions workflow (`.github/workflows/tests.yml`) to include Laravel 13 and PHPUnit 12 in the test matrix, and excluded unsupported combinations to prevent build failures.
* Modified the dependency installation step in the workflow to explicitly require the correct PHPUnit version for each test run.
* Enabled manual triggering of the test workflow by adding `workflow_dispatch` to the workflow triggers.
